### PR TITLE
Fixed a common crash when switching spells

### DIFF
--- a/src/main/java/electroblob/wizardry/WandHelper.java
+++ b/src/main/java/electroblob/wizardry/WandHelper.java
@@ -93,7 +93,7 @@ public class WandHelper {
 
 			int selectedSpell = wand.stackTagCompound.getInteger(SELECTED_SPELL_KEY);
 
-			if(selectedSpell < spells.length){
+			if(selectedSpell < spells.length && selectedSpell >= 0){
 				return spells[selectedSpell];
 			}
 		}


### PR DESCRIPTION
Switching spells causes ArrayIndexOutOfBoundsException: -1 when the next spell is empty. 

I made a simple fix.